### PR TITLE
Added support for the baseurl option

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,24 +7,24 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <!-- Le styles -->
-    <link href="/assets/css/bootstrap.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/assets/css/bootstrap.css" rel="stylesheet">
     <style>
       body { padding-top: 60px; /* 60px to make the container go all the way
       to the bottom of the topbar */ }
     </style>
-    <link href="/assets/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="/assets/css/docs.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/assets/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="{{ site.baseurl }}/assets/css/docs.css" rel="stylesheet">
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">
       </script>
     <![endif]-->
     <!-- Le fav and touch icons -->
-    <link rel="shortcut icon" href="assets/ico/favicon.ico">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="assets/ico/apple-touch-icon-144-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="assets/ico/apple-touch-icon-114-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="assets/ico/apple-touch-icon-72-precomposed.png">
-    <link rel="apple-touch-icon-precomposed" href="assets/ico/apple-touch-icon-57-precomposed.png">
+    <link rel="shortcut icon" href="{{ site.baseurl }}/assets/ico/favicon.ico">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/assets/ico/apple-touch-icon-144-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/assets/ico/apple-touch-icon-114-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.baseurl }}/assets/ico/apple-touch-icon-72-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/assets/ico/apple-touch-icon-57-precomposed.png">
     <style>
     </style>
   </head>
@@ -33,7 +33,7 @@
     <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <a href="/" class="brand"><img src="http://s3.amazonaws.com/jetstrap-site/images/jetstrap_logo.png"></a>
+          <a href="{{ site.baseurl }}/" class="brand"><img src="http://s3.amazonaws.com/jetstrap-site/images/jetstrap_logo.png"></a>
           <ul class="nav pull-right">
             <li><a href="http://jetstrap.com/">Jetstrap</a></li>
             <li><a href="http://jetstrap.com/#about">About</a></li>
@@ -50,10 +50,10 @@
         <div class="span3">
           <ul id="menu" class="nav nav-list" data-spy="affix">
             <li class="nav-header">JETSTRAP DOCS</li>
-            <li data-section=""><a href="/">Home</a></li>
+            <li data-section=""><a href="{{ site.baseurl }}/">Home</a></li>
             <li class="nav-header">USING JETSTRAP</li>
-            <li data-section="jetstrap/gettingstarted"><a href="/jetstrap/gettingstarted.html">Getting Started</a></li>
-            <li data-section="builder/components"><a href="/builder/components.html">Components</a></li>
+            <li data-section="jetstrap/gettingstarted"><a href="{{ site.baseurl }}/jetstrap/gettingstarted.html">Getting Started</a></li>
+            <li data-section="builder/components"><a href="{{ site.baseurl }}/builder/components.html">Components</a></li>
             <li class="nav-header">SUPPORT</li>
             <li><a href="mailto:support@jetstrap.com">Contact Support</a></li>
           </ul>
@@ -69,7 +69,7 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js">
     </script>
-    <script src="/assets/js/bootstrap.js">
+    <script src="{{ site.baseurl }}/assets/js/bootstrap.js">
     </script>
 
     <script>


### PR DESCRIPTION
Jekyll has a `baseurl` option to allow the site to be hosted in a sub-directory of the webroot.
This PR adds support for hosting the jetstrap docs with an alternative baseurl
